### PR TITLE
Add: ECR image scan enable

### DIFF
--- a/remediation/ecr-image-scan-enable/README.md
+++ b/remediation/ecr-image-scan-enable/README.md
@@ -1,0 +1,11 @@
+# ECR image scan enable
+
+## What is this?
+
+This is a runbook for enabling image scan when the image is pushed to the ECR repository.
+ECR image scan can help you to identify software vulnerabilities in your container images.
+
+## cloudformation.yml
+
+This CloudFormation template creates a AWS Automation function that enable ECR image scan automatically.
+It contains Config rule to trigger the Automation function when not ECR image scan is enabled.

--- a/remediation/ecr-image-scan-enable/cloudformation.yml
+++ b/remediation/ecr-image-scan-enable/cloudformation.yml
@@ -1,0 +1,99 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "ECR Runbook"
+
+Resources:
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-document.html
+  SSMDocumentECRImageScanningEnable:
+    Type: "AWS::SSM::Document"
+    Properties:
+      Content:
+        schemaVersion: "0.3"
+        description: "Turn on ECR image scan"
+        parameters:
+          AutomationAssumeRole:
+            type: "String"
+            description: "(Optional) The ARN of the role that allows Automation to perform the actions on your behalf."
+            default: ""
+          RepositoryName:
+            type: "String"
+            allowedPattern: "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*"
+            description: "The name of the repository in which to update the image scanning configuration setting."
+        assumeRole: "{{ AutomationAssumeRole }}"
+        mainSteps:
+          - description: "APIref. https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_PutImageScanningConfiguration.html"
+            name: "PutImageScanningConfiguration"
+            action: "aws:executeAwsApi"
+            isEnd: true
+            inputs:
+              Service: "ecr"
+              Api: "PutImageScanningConfiguration"
+              repositoryName: "{{ RepositoryName }}"
+              imageScanningConfiguration:
+                scanOnPush: true
+      DocumentFormat: "YAML"
+      DocumentType: "Automation"
+      Name: "ECRImageScanningEnable"
+
+  IAMRoleAutomationServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ssm.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:ssm:*:${AWS::AccountId}:automation-execution/*
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole
+      Policies:
+        - PolicyName: "AutomationServiceRolePolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:PutImageScanningConfiguration"
+                Resource: "*"
+      Path: "/"
+      RoleName: AutomationServiceRole
+
+  ConfigConfigRuleECRPrivateImageScanningEnabled:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: "ecr-private-image-scanning-enabled"
+      Description: "Checks if a private Amazon Elastic Container Registry (ECR) repository has image scanning enabled. The rule is NON_COMPLIANT if the private ECR repository's scan frequency is not on scan on push or continuous scan."
+      Source:
+        Owner: "AWS"
+        SourceIdentifier: "ECR_PRIVATE_IMAGE_SCANNING_ENABLED"
+      MaximumExecutionFrequency: "TwentyFour_Hours"
+
+  ConfigRemediationConfigurationECRImageScanningEnable:
+    Type: AWS::Config::RemediationConfiguration
+    Properties:
+      Automatic: true
+      ConfigRuleName: !Ref ConfigConfigRuleECRPrivateImageScanningEnabled
+      ExecutionControls:
+        SsmControls:
+          ConcurrentExecutionRatePercentage: 25
+          ErrorPercentage: 35
+      MaximumAutomaticAttempts: 5
+      RetryAttemptSeconds: 60
+      TargetId: !Ref SSMDocumentECRImageScanningEnable
+      TargetType: "SSM_DOCUMENT"
+      TargetVersion: "1"
+      Parameters:
+        AutomationAssumeRole:
+          StaticValue:
+            Values:
+              - !GetAtt IAMRoleAutomationServiceRole.Arn
+        RepositoryName:
+          ResourceValue:
+            Value: "RESOURCE_ID"

--- a/remediation/ecr-image-scan-enable/runbook.yml
+++ b/remediation/ecr-image-scan-enable/runbook.yml
@@ -1,0 +1,24 @@
+Content:
+schemaVersion: "0.3"
+description: "Turn on ECR image scan"
+parameters:
+  AutomationAssumeRole:
+    type: "String"
+    description: "(Optional) The ARN of the role that allows Automation to perform the actions on your behalf."
+    default: ""
+  RepositoryName:
+    type: "String"
+    allowedPattern: "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*"
+    description: "The name of the repository in which to update the image scanning configuration setting."
+assumeRole: "{{ AutomationAssumeRole }}"
+mainSteps:
+  - description: "APIref. https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_PutImageScanningConfiguration.html"
+    name: "PutImageScanningConfiguration"
+    action: "aws:executeAwsApi"
+    isEnd: true
+    inputs:
+      Service: "ecr"
+      Api: "PutImageScanningConfiguration"
+      repositoryName: "{{ RepositoryName }}"
+      imageScanningConfiguration:
+        scanOnPush: true

--- a/remediation/iam-password-delete/README.md
+++ b/remediation/iam-password-delete/README.md
@@ -1,0 +1,12 @@
+# IAM password delete
+
+## What is this?
+
+This is a runbook for deleting IAM users' passwords.
+IAM users' password will be used to authenticate to the AWS Management Console.
+If your organization uses SSO, you may want to delete IAM users' passwords to prevent unauthorized access to the AWS Management Console.
+
+## cloudformation.yml
+
+This CloudFormation template creates a AWS Automation function that deletes IAM users' passwords.
+It contains CloudTrail event pattern to trigger the Automation function when a password is created and IAM role for the Automation function.

--- a/remediation/iam-password-delete/cloudformation.yml
+++ b/remediation/iam-password-delete/cloudformation.yml
@@ -1,0 +1,139 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Delete IAM login Password SSM Automation"
+
+Resources:
+  SSMDocumentIAMDeletePassword:
+    Type: "AWS::SSM::Document"
+    Properties:
+      Content:
+        schemaVersion: "0.3"
+        description: "Delete the password to reject console access."
+        parameters:
+          AutomationAssumeRole:
+            type: String
+            description: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+            default: ""
+          IAMName:
+            type: String
+            description: The name of the IAM user in which to delete the password to reject console access.
+        assumeRole: "{{ AutomationAssumeRole }}"
+        mainSteps:
+          - name: WaitForCreateLoginProfile
+            action: aws:waitForAwsResourceProperty
+            isEnd: false
+            inputs:
+              Service: "iam"
+              Api: "GetLoginProfile"
+              PropertySelector: "$.LoginProfile.UserName"
+              UserName: "{{ IAMName }}"
+              DesiredValues:
+                - "{{ IAMName }}"
+          - name: sleep
+            action: aws:sleep
+            inputs:
+              Duration: PT5S # wait for 5 seconds
+          - name: DeleteLoginProfile
+            action: aws:executeAwsApi
+            isEnd: true
+            inputs:
+              Service: "iam"
+              Api: "DeleteLoginProfile"
+              UserName: "{{ IAMName }}"
+      DocumentFormat: "YAML"
+      DocumentType: "Automation"
+      Name: "IAMDeletePassword"
+      UpdateMethod: "NewVersion"
+
+  IAMRoleSSMAutomationExecution:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ssm.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:ssm:*:${AWS::AccountId}:automation-execution/*
+      Policies:
+        - PolicyName: "AutomationServicePolicyDeleteIAMPassword"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "iam:DeleteLoginProfile"
+                  - "iam:GetLoginProfile"
+                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:user/*"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole
+      Path: /
+      Description: New IAM role to allow SSM access.
+
+  IAMRoleEventBridgeInvokeAutomation:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: "EventBridgeServicePolicyInvokeAutomation"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:StartAutomationExecution
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${SSMDocumentIAMDeletePassword}:$DEFAULT"
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !GetAtt IAMRoleSSMAutomationExecution.Arn
+                Condition:
+                  StringLikeIfExists:
+                    iam:PassedToService: ssm.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/PowerUserAccess
+      Path: /service-role/
+
+  EventRuleIAMCreated:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: "IAMCreated"
+      EventPattern:
+        source:
+          - "aws.iam"
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "iam.amazonaws.com"
+          eventName:
+            - "CreateLoginProfile"
+      State: "ENABLED"
+      EventBusName: "default"
+      Targets:
+        - Id: "SSMDocumentIAMDeletePassword"
+          Arn: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${SSMDocumentIAMDeletePassword}:$DEFAULT"
+          RoleArn: !GetAtt "IAMRoleEventBridgeInvokeAutomation.Arn"
+          InputTransformer:
+            InputPathsMap:
+              IAMName: $.detail.requestParameters.userName
+            InputTemplate: !Sub |
+              {
+                "AutomationAssumeRole":["${IAMRoleSSMAutomationExecution.Arn}"],
+                "IAMName":[<IAMName>]
+              }

--- a/remediation/iam-password-delete/runbook.yml
+++ b/remediation/iam-password-delete/runbook.yml
@@ -1,0 +1,33 @@
+schemaVersion: "0.3"
+description: "Delete the password to reject console access."
+assumeRole: "{{ AutomationAssumeRole }}"
+parameters:
+  AutomationAssumeRole:
+    type: String
+    description: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+    default: ""
+  IAMName:
+    type: String
+    description: The name of the IAM user in which to delete the password to reject console access.
+mainSteps:
+  - name: WaitForCreateLoginProfile
+    action: aws:waitForAwsResourceProperty
+    isEnd: false
+    inputs:
+      Service: "iam"
+      Api: "GetLoginProfile"
+      PropertySelector: "$.LoginProfile.UserName"
+      UserName: "{{ IAMName }}"
+      DesiredValues:
+        - "{{ IAMName }}"
+  - name: sleep
+    action: aws:sleep
+    inputs:
+      Duration: PT5S # wait for 5 seconds
+  - name: DeleteLoginProfile
+    action: aws:executeAwsApi
+    isEnd: true
+    inputs:
+      Service: "iam"
+      Api: "DeleteLoginProfile"
+      UserName: "{{ IAMName }}"


### PR DESCRIPTION
# ECR image scan enable

## What is this?

This is a runbook for enabling image scan when the image is pushed to the ECR repository.
ECR image scan can help you to identify software vulnerabilities in your container images.

## cloudformation.yml

This CloudFormation template creates a AWS Automation function that enable ECR image scan automatically.
It contains Config rule to trigger the Automation function when not ECR image scan is enabled.
